### PR TITLE
Disconnect peer sending same messages as spam

### DIFF
--- a/gossip/handler.go
+++ b/gossip/handler.go
@@ -61,9 +61,6 @@ const (
 	// txChanSize is the size of channel listening to NewTxsNotify.
 	// The number is referenced from the size of tx pool.
 	txChanSize = 4096
-
-	sameMsgDisconnectThreshold = 10
-	maxMsgFrequency            = 1 * time.Second
 )
 
 func errResp(code errCode, format string, v ...interface{}) error {
@@ -126,11 +123,6 @@ type snapsyncState struct {
 	cancel    func() error
 	updatesCh chan snapsyncStateUpd
 	quit      chan struct{}
-}
-
-type msgDOSwatch struct {
-	timestamp []time.Time
-	count     int
 }
 
 type handler struct {
@@ -198,8 +190,6 @@ type handler struct {
 	peerWG  sync.WaitGroup
 	started sync.WaitGroup
 
-	msgCache map[uint64]map[string]*msgDOSwatch
-
 	logger.Instance
 }
 
@@ -226,7 +216,6 @@ func newHandler(
 		txsyncCh:             make(chan *txsync),
 		quitSync:             make(chan struct{}),
 		quitProgressBradcast: make(chan struct{}),
-		msgCache:             make(map[uint64]map[string]*msgDOSwatch),
 
 		snapState: snapsyncState{
 			updatesCh: make(chan snapsyncStateUpd, 128),
@@ -1151,20 +1140,8 @@ func (h *handler) handleMsg(p *peer) error {
 			return errResp(ErrMsgTooLarge, "%v", msg)
 		}
 
-		if h.msgCache[msg.Code] == nil {
-			h.msgCache[msg.Code] = make(map[string]*msgDOSwatch)
-		}
-		id := msg.String()
-		dosWatch := h.msgCache[msg.Code][id]
-		if dosWatch == nil {
-			dosWatch = new(msgDOSwatch)
-		}
-		dosWatch.timestamp = append(dosWatch.timestamp, time.Now())
-		if len(dosWatch.timestamp) > sameMsgDisconnectThreshold {
-			if time.Now().Sub(dosWatch.timestamp[0]) > maxMsgFrequency {
-				return errors.New("too frequent")
-			}
-			dosWatch.timestamp = dosWatch.timestamp[:0]
+		if err := p.preventDOSMsgFlood(msg); err != nil {
+			return err
 		}
 
 		pid := p.id
@@ -1195,6 +1172,7 @@ func (h *handler) handleMsg(p *peer) error {
 		if (len(chunk.Events) != 0) && (len(chunk.IDs) != 0) {
 			return errors.New("expected either events or event hashes")
 		}
+
 		var last hash.Event
 		if len(chunk.IDs) != 0 {
 			h.handleEventHashes(p, chunk.IDs)
@@ -1217,6 +1195,10 @@ func (h *handler) handleMsg(p *peer) error {
 		}
 		if request.Limit.Size > protocolMaxMsgSize*2/3 {
 			return errResp(ErrMsgTooLarge, "%v", msg)
+		}
+
+		if err := p.preventDOSMsgFlood(msg); err != nil {
+			return err
 		}
 
 		pid := p.id
@@ -1264,6 +1246,10 @@ func (h *handler) handleMsg(p *peer) error {
 			return errResp(ErrMsgTooLarge, "%v", msg)
 		}
 
+		if err := p.preventDOSMsgFlood(msg); err != nil {
+			return err
+		}
+
 		pid := p.id
 		_, peerErr := h.brSeeder.NotifyRequestReceived(brstreamseeder.Peer{
 			ID:        pid,
@@ -1308,6 +1294,10 @@ func (h *handler) handleMsg(p *peer) error {
 		}
 		if request.Limit.Size > protocolMaxMsgSize*2/3 {
 			return errResp(ErrMsgTooLarge, "%v", msg)
+		}
+
+		if err := p.preventDOSMsgFlood(msg); err != nil {
+			return err
 		}
 
 		pid := p.id

--- a/gossip/handler.go
+++ b/gossip/handler.go
@@ -61,6 +61,9 @@ const (
 	// txChanSize is the size of channel listening to NewTxsNotify.
 	// The number is referenced from the size of tx pool.
 	txChanSize = 4096
+
+	sameMsgDisconnectThreshold = 10
+	maxMsgFrequency            = 1 * time.Second
 )
 
 func errResp(code errCode, format string, v ...interface{}) error {
@@ -123,6 +126,11 @@ type snapsyncState struct {
 	cancel    func() error
 	updatesCh chan snapsyncStateUpd
 	quit      chan struct{}
+}
+
+type msgDOSwatch struct {
+	timestamp []time.Time
+	count     int
 }
 
 type handler struct {
@@ -190,6 +198,8 @@ type handler struct {
 	peerWG  sync.WaitGroup
 	started sync.WaitGroup
 
+	msgCache map[uint64]map[string]*msgDOSwatch
+
 	logger.Instance
 }
 
@@ -216,6 +226,7 @@ func newHandler(
 		txsyncCh:             make(chan *txsync),
 		quitSync:             make(chan struct{}),
 		quitProgressBradcast: make(chan struct{}),
+		msgCache:             make(map[uint64]map[string]*msgDOSwatch),
 
 		snapState: snapsyncState{
 			updatesCh: make(chan snapsyncStateUpd, 128),
@@ -1138,6 +1149,22 @@ func (h *handler) handleMsg(p *peer) error {
 		}
 		if request.Limit.Size > protocolMaxMsgSize*2/3 {
 			return errResp(ErrMsgTooLarge, "%v", msg)
+		}
+
+		if h.msgCache[msg.Code] == nil {
+			h.msgCache[msg.Code] = make(map[string]*msgDOSwatch)
+		}
+		id := msg.String()
+		dosWatch := h.msgCache[msg.Code][id]
+		if dosWatch == nil {
+			dosWatch = new(msgDOSwatch)
+		}
+		dosWatch.timestamp = append(dosWatch.timestamp, time.Now())
+		if len(dosWatch.timestamp) > sameMsgDisconnectThreshold {
+			if time.Now().Sub(dosWatch.timestamp[0]) > maxMsgFrequency {
+				return errors.New("too frequent")
+			}
+			dosWatch.timestamp = dosWatch.timestamp[:0]
 		}
 
 		pid := p.id

--- a/gossip/peer.go
+++ b/gossip/peer.go
@@ -1,6 +1,7 @@
 package gossip
 
 import (
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"sync"
@@ -609,12 +610,15 @@ func (p *peer) preventDOSMsgFlood(msg p2p.Msg) error {
 		p.msgTracker[msg.Code] = make(map[string]*msgDOSwatch)
 	}
 
-	// create a "hash" for the map
+	// create a "hash" for the map: we need its byte representation
 	raw, err := rlp.EncodeToBytes(msg)
 	if err != nil {
 
 	}
-	id := string(raw)
+	// calc a hash of the msg, so we don't need to store the complete msg
+	h := sha256.New()
+	h.Write(raw)
+	id := string(h.Sum(nil))
 
 	// check if there already is a map for this message
 	dosWatch := p.msgTracker[msg.Code][id]


### PR DESCRIPTION
A peer can send many messages with the same content many times. This PR tries to prevent potential DOS attacks by saving incoming messages with a timestamp and then disconnecting a peer if it issues too many messages per threshold.

This should be carefully reviewed. Because in any case, this PR will add overhead to message handling:

* messages need to be saved to be able to detect if the same has been sent already -> more memory
* more processing time needs to be spent to check if a message is exceeding the thresholds
* some cleanup must be done to avoid memory leaks
* each message is being "hashed" (to be able to save it and then compare with future messages) by encoding to RLP again -> more processing overhead
* Also the actual thresholds should be carefully evaluated (maxMsgFrequency and sameMsgDisconnectThreshold).